### PR TITLE
Robustify archive name pattern detection

### DIFF
--- a/fix-crashplan.sh
+++ b/fix-crashplan.sh
@@ -74,7 +74,9 @@ test "x${CRASHPLAN_INSTALL_FILE}" != "x" || usage
 test -f "${CRASHPLAN_INSTALL_FILE}" || die "Unable to find file at ${CRASHPLAN_INSTALL_FILE}"
 
 # Check the filename matches expectations
-OK=$(echo ${CRASHPLAN_INSTALL_FILE} | sed  's/CrashPlanSmb_10\.[0-9]\+\.[0-9]\+_[0-9]\+_[0-9]\+_Linux.tgz/OK/')
+# Prevent issues w/ leading paths
+CRASHPLAN_INSTALL_FILENAME="$(basename $CRASHPLAN_INSTALL_FILE)"
+OK=$(echo ${CRASHPLAN_INSTALL_FILENAME} | sed  's/CrashPlanSmb_10\.[0-9]\+\.[0-9]\+_[0-9]\+_[0-9]\+_Linux.tgz/OK/')
 test "x${OK}" = "xOK" || die "Filename does not match expected pattern of 'CrashPlanSmb_10.X.X_XXXXXXXXXXXXXX_XX_Linux.tgz'"
 
 # And, check that it has the right filetype


### PR DESCRIPTION
First, thank you for this useful script, which I found after scouring Reddit for my crash (I am running Fedora 36). It's very useful to have an automated, reliable way to perform the modification needed/workaround :+1: 

Depending on the path specified to the CrashPlan archive, the script fails when checking the archive filename. Here is a sample session:
```
❯ bash -x ./fix-crashplan.sh ~/Downloads/Crashplan/CrashPlanSmb_10.2.1_15252000061021_16_Linux.tgz                                                                                                                                            
+ set -euo pipefail                                                                                                                                                                                                                           
+ SCRIPTNAME=fix-crashplan                                                                                                                                                                                                                    
+ OUTPUTCOLOR=                                                                                                                                                                                                                                
+ NOCOLOR=                                                                                                                                                                                                                                    
+ onLoad                                                                                                                                                                                                                                      
+ '[' -t 1 ']'                                                                                                                                                                                                                                
++ tput setaf 2                                                                                                                                                                                                                               
+ OUTPUTCOLOR=''                                                                                                                                                                                                                              
++ tput sgr0                                                                                                                                                                                                                                  
+ NOCOLOR=''                                                                                                                                                                                                                                  
+ CRASHPLAN_INSTALL_DIR=/usr/local/crashplan                                                                                                                                                                                                  
+ CRASHPLAN_NATIVE_LIBS_SOURCE=ubuntu20                                                                                                                                                                                                       
+ which gzip                                                                                                                                                                                                                                  
+ which tar                                                                                                                                                                                                                                   
+ which cpio                                                                                                                                                                                                                                  
+ which sed                                                                                                                                                                                                                                   
+ set +u                                                                                                                                                                                                                                      
+ CRASHPLAN_INSTALL_FILE=/home/vincent/Downloads/Crashplan/CrashPlanSmb_10.2.1_15252000061021_16_Linux.tgz                                                                                                                                    
+ set -u                                                                                                                                                                                                                                      
+ test x/home/vincent/Downloads/Crashplan/CrashPlanSmb_10.2.1_15252000061021_16_Linux.tgz '!=' x                                                                                                                                              
+ test -f /home/vincent/Downloads/Crashplan/CrashPlanSmb_10.2.1_15252000061021_16_Linux.tgz                                                                                                                                                   
++ echo /home/vincent/Downloads/Crashplan/CrashPlanSmb_10.2.1_15252000061021_16_Linux.tgz                                                                                                                                                     
++ sed 's/CrashPlanSmb_10\.[0-9]\+\.[0-9]\+_[0-9]\+_[0-9]\+_Linux.tgz/OK/'                                                                                                                                                                    
+ OK=/home/vincent/Downloads/Crashplan/OK                                                                                                                                                                                                     
+ test x/home/vincent/Downloads/Crashplan/OK = xOK                                                                                                                                                                                            
+ die 'Filename does not match expected pattern of '\''CrashPlanSmb_10.X.X_XXXXXXXXXXXXXX_XX_Linux.tgz'\'''                                                                                                                                   
++ date +%T                                                                                                                                                                                                                                   
+ echo '[fix-crashplan] 14:16:38 ERROR:' 'Filename does not match expected pattern of '\''CrashPlanSmb_10.X.X_XXXXXXXXXXXXXX_XX_Linux.tgz'\'''                                                                                                
[fix-crashplan] 14:16:38 ERROR: Filename does not match expected pattern of 'CrashPlanSmb_10.X.X_XXXXXXXXXXXXXX_XX_Linux.tgz'                                                                                                                 
+ exit 1  
```